### PR TITLE
feat: add fiat cash management to crypto-com-app skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Each skill contains a `SKILL.md` with:
 
 | Skill | Purpose | When to Use |
 |-------|---------|-------------|
-| crypto-com-app | Trading and market data | User wants to buy/sell/swap crypto, check balances, token price, discover coins and view trades through crypto.com App |
+| crypto-com-app | Trading, cash management, and market data | User wants to buy/sell/swap crypto, check balances, token price, discover coins, view trades, deposit/withdraw fiat currencies, or manage bank accounts through crypto.com App |
 | crypto-com-exchange | Trading and market data | User wants to buy/sell/swap crypto, check prices, discover coins through crypto.com Exchange |
 
 ## Environment Setup

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Each skill has its own `SKILL.md` and references. Install one or both depending 
 - **History**: View recent transaction history
 - **Trading Limits**: Check weekly trading budget usage
 - **Kill Switch**: Emergency API key revocation
+- **Cash Management**: Deposit and withdraw fiat currencies, view bank accounts, check payment networks, and email deposit instructions
 
 ### Quickstart
 
@@ -97,8 +98,9 @@ crypto-com-app/
     │   ├── api.ts      # HTTP client, HMAC signing
     │   └── output.ts   # Structured output + error codes
     ├── account.ts      # Balances, trading limit, kill switch
-    ├── trade.ts        # Quotations, orders, history
-    └── coins.ts        # Coin discovery
+    ├── coins.ts        # Coin discovery
+    ├── fiat.ts         # Cash deposits, withdrawals, bank accounts
+    └── trade.ts        # Quotations, orders, history
 ```
 
 ### Prerequisites

--- a/crypto-com-app/SKILL.md
+++ b/crypto-com-app/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: crypto-com-app
-description: "Execute crypto trades (buy, sell, swap, exchange) and query account balances, market prices, and transaction history via the Crypto.com APP API. View weekly trading limits and portfolio positions. Use when the user wants to trade, purchase, sell, or swap cryptocurrency, check token prices or portfolio balances, view recent trades, discover coins, or activate the kill switch. Supports BTC, ETH, CRO, and 200+ tokens across fiat and crypto wallets."
+description: "Execute crypto trades (buy, sell, swap, exchange), manage cash deposits and withdrawals, and query account balances, market prices, and transaction history via the Crypto.com APP API. View weekly trading limits, portfolio positions, bank accounts, and payment networks. Use when the user wants to trade cryptocurrency, deposit or withdraw cash, check bank account details, view deposit instructions, or manage fiat wallet operations. Supports BTC, ETH, CRO, and 200+ tokens across fiat and crypto wallets."
 user-invocable: true
 metadata:
   author: "Crypto.com"
-  version: "1.0.1"
+  version: "1.0.2"
   homepage: "https://crypto.com"
   license: "Apache-2.0"
   tags: ["crypto", "trading", "api"]
@@ -152,6 +152,69 @@ npx tsx $SKILL_DIR/scripts/coins.ts search '{"keyword":"BTC","sort_by":"rank","s
 
 **Key response fields per coin:** `rails_id` (identical to `currency_id` / `currency` in trade and account APIs — use this to cross-reference), `price_native`, `price_usd`, `percent_change_*_native` (price performance over past timeframes, e.g. `percent_change_24h_native`).
 
+### Cash (Fiat) Commands
+
+Cash commands handle deposits, withdrawals, and bank account management.
+
+```bash
+# Cash overview — balances + available payment networks per currency
+npx tsx $SKILL_DIR/scripts/fiat.ts discover
+
+# Payment networks for a currency
+npx tsx $SKILL_DIR/scripts/fiat.ts payment-networks <CURRENCY>
+
+# Deposit method details (bank routing info)
+npx tsx $SKILL_DIR/scripts/fiat.ts deposit-methods <CURRENCY> <DEPOSIT_METHOD>
+
+# Email deposit instructions to user
+npx tsx $SKILL_DIR/scripts/fiat.ts email-deposit-info <CURRENCY> <VIBAN_TYPE>
+
+# Withdrawal details (quotas, fees, minimums)
+npx tsx $SKILL_DIR/scripts/fiat.ts withdrawal-details <CURRENCY> <VIBAN_TYPE>
+
+# Create withdrawal order (returns order with fees + receivable amount)
+npx tsx $SKILL_DIR/scripts/fiat.ts create-withdrawal-order '<json-params>'
+
+# Execute withdrawal (may prompt for TOTP authenticator code)
+npx tsx $SKILL_DIR/scripts/fiat.ts create-withdrawal <ORDER_ID>
+
+# List linked bank accounts
+npx tsx $SKILL_DIR/scripts/fiat.ts bank-accounts [CURRENCY]
+```
+
+**Key parameters:**
+
+| Parameter | Description | Example values |
+|-----------|-------------|----------------|
+| `CURRENCY` | Uppercase currency code | `USD`, `EUR`, `GBP`, `AUD` |
+| `DEPOSIT_METHOD` | Network ID from `payment-networks` | `us_ach`, `sepa`, `uk_fps` |
+| `VIBAN_TYPE` | Same as deposit method / withdrawal network | `us_ach`, `sepa`, `uk_fps` |
+
+**Withdrawal order JSON params:**
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `currency` | Yes | Currency code (e.g. `"USD"`) |
+| `amount` | Yes | Amount as string (e.g. `"500.00"`) |
+| `viban_type` | Yes | Payment network (e.g. `"us_ach"`) |
+| `bank_account_id` | No | Specific bank account ID |
+
+**Example — "How do I deposit USD?":**
+
+1. Run: `npx tsx $SKILL_DIR/scripts/fiat.ts payment-networks USD`
+2. Read `data` array — each entry has `deposit_push_payment_networks` (e.g. `["us_ach", "us_wire_transfer"]`)
+3. For details: `npx tsx $SKILL_DIR/scripts/fiat.ts deposit-methods USD us_ach`
+4. Read `data` array — contains `bank_details` with routing number, account number, etc.
+
+**Example — "Withdraw 500 USD via ACH":**
+
+1. Run: `npx tsx $SKILL_DIR/scripts/fiat.ts withdrawal-details USD us_ach` — check quotas and fees
+2. Run: `npx tsx $SKILL_DIR/scripts/fiat.ts create-withdrawal-order '{"currency":"USD","amount":"500","viban_type":"us_ach"}'`
+3. Read `data.id` (order ID), `data.fee`, `data.receivable_amount` from response
+4. **Confirm with user:** "Withdraw 500 USD via ACH. Fee: {fee}. You'll receive: {receivable_amount}. Confirm?"
+5. If YES: `npx tsx $SKILL_DIR/scripts/fiat.ts create-withdrawal <order-id>`
+6. If TOTP required, the script will prompt for a 6-digit authenticator code on stderr
+
 ### Output Format
 
 Every script prints structured JSON to stdout:
@@ -217,6 +280,11 @@ These are the *specific* API error codes that appear inside the `error_message` 
 | `failed_to_create_transaction` | Transaction creation failed | Retry or contact support |
 | `key_not_active` | API key revoked or expired | Generate a new API key, update env vars |
 | `api_key_not_found` | Key doesn't exist or belongs to another user | Verify correct key is set in `CDC_API_KEY` |
+| `totp_required` | Withdrawal needs 2FA code | Script handles automatically — prompts user for authenticator code |
+| `withdrawal_limit_exceeded` | Daily/monthly quota exceeded | Show limits via `withdrawal-details`, reduce amount |
+| `invalid_bank_account` | Bank account not eligible | Check `bank-accounts` for valid accounts with `status: completed` |
+| `withdrawal_cooling_off` | Recently changed withdrawal settings | Wait for cooling-off period, report `error_message` to user |
+| `email_cooldown` | Too many deposit info emails | Wait for cooldown period (shown in error), try again later |
 
 For dynamic errors (limit exceeded, currency disabled, cooling-off, etc.), report the `error` and `error_message` directly to the user. For full details, see [references/errors.md](references/errors.md).
 
@@ -274,6 +342,10 @@ When the user asks to buy, sell, or swap crypto, **always** follow this three-st
 ### 5. Account & History
 - **History:** Run `npx tsx $SKILL_DIR/scripts/trade.ts history` — display the entries from `data`.
 - **Weekly Trading Limit:** Run `npx tsx $SKILL_DIR/scripts/account.ts trading-limit` — display as: "📊 Weekly Trading Limit: {data.used} / {data.limit} USD (Remaining: {data.remaining} USD)".
+- **Fiat vs Crypto balance routing:** When the user asks about a specific currency balance, determine whether it is a **fiat currency** (USD, EUR, GBP, AUD, SGD, CAD, BRL, etc.) or a **crypto token** (BTC, ETH, CRO, etc.).
+    - **Fiat currency** → run `npx tsx $SKILL_DIR/scripts/account.ts balances fiat` (shows all fiat balances) or `npx tsx $SKILL_DIR/scripts/fiat.ts discover` (shows balances + payment networks). **Never** use `balance <SYMBOL>` for fiat currencies — it queries the crypto wallet and will always return 0.
+    - **Crypto token** → run `npx tsx $SKILL_DIR/scripts/account.ts balance <SYMBOL>`.
+    - **Unsure** → run `npx tsx $SKILL_DIR/scripts/account.ts balances all` to show both fiat and crypto.
 - **Balances (Categorized):**
     - If "List Fiat": run `npx tsx $SKILL_DIR/scripts/account.ts balances fiat`.
     - If "List Crypto": run `npx tsx $SKILL_DIR/scripts/account.ts balances crypto`.
@@ -298,3 +370,53 @@ When the user asks to buy, sell, or swap crypto, **always** follow this three-st
 - **Crypto Header:** "🪙 Crypto Balances"
 - Always list Fiat section before Crypto section when both are requested.
 - **Never display zero-balance assets.** Only show assets with a balance greater than 0. If all assets in a category are zero, show "No holdings" under that header.
+
+### 8. Cash Deposit & Withdrawal
+
+**Terminology:** Use "cash" (not "fiat") in user-facing messages. Say "your cash balance" not "your fiat balance".
+
+**Currency disambiguation:** If the user doesn't specify a currency, run `discover` first.
+- **One currency with balance** → auto-select it and proceed.
+- **Multiple currencies with balances** → present the list and ask the user to choose before proceeding.
+- **No balances** → inform: "You don't have any cash balances yet." and stop.
+
+**Deposit flow:**
+1. Run `discover` to show the user their cash currencies and available networks
+2. User picks a currency and network — run `deposit-methods` to get bank details
+3. Present the bank details (routing number, account number, bank name, reference)
+4. Optionally run `email-deposit-info` to email instructions to the user
+5. **Rate limit:** `email-deposit-info` is limited to 5 requests per 30 minutes. On cooldown error, inform user and show the `cooldown_in_seconds` value.
+
+**Withdrawal flow:**
+1. Run `bank-accounts <currency>` to list eligible accounts (filter to `status: "completed"` only)
+   - **One eligible account** → auto-select it
+   - **Multiple eligible accounts** → present the list (bank name, account identifier, networks) and ask user to choose
+   - **No eligible accounts** → inform: "No eligible bank accounts found for {currency}. You need to link a bank account first." and stop
+2. Run `withdrawal-details` to check quotas, fees, and minimums
+3. Run `create-withdrawal-order` with amount, network, and `bank_account_id` from step 1 — returns order with fees
+4. **ALWAYS confirm with user** before executing (regardless of `memory.confirmation_required`):
+   - Show: amount, fee, receivable amount, network, destination bank account, processing time
+   - Require explicit "YES" to proceed
+5. Run `create-withdrawal` with the order ID
+6. **TOTP handling:** If the API returns `totp_required`, the script prompts for a 6-digit authenticator code on stderr. The agent should tell the user: "Please enter your 6-digit authenticator code when prompted." Never try to generate or bypass the TOTP.
+
+**Bank accounts:**
+- Run `bank-accounts` to list linked accounts. Filter by currency if specified.
+- Only accounts with `status: "completed"` are eligible for withdrawals.
+- Each account shows `withdrawal_payment_networks` — use these as valid `viban_type` values.
+
+**Deposit methods — vendor selection:**
+- `deposit-methods` returns a `vendor_list` array. Each vendor has a `status` field.
+- Only show vendors with `status: "created"` (active). Ignore `"uncreated"` vendors.
+- If multiple created vendors exist, default to the first one in the list.
+
+**Cash commands quick reference:**
+
+| User says | Commands to run |
+|-----------|----------------|
+| "How do I deposit USD?" | `payment-networks USD` then `deposit-methods USD <network>` |
+| "Email me deposit instructions" | `email-deposit-info <currency> <viban_type>` |
+| "Show my bank accounts" | `bank-accounts` |
+| "What are my withdrawal limits?" | `withdrawal-details <currency> <viban_type>` |
+| "Withdraw 500 USD" | `withdrawal-details` -> `create-withdrawal-order` -> confirm -> `create-withdrawal` |
+| "What currencies can I deposit?" | `discover` |

--- a/crypto-com-app/_meta.json
+++ b/crypto-com-app/_meta.json
@@ -1,5 +1,5 @@
 {
   "slug": "crypto-com-app",
-  "version": "1.0.1",
-  "publishedAt": 1773623744
+  "version": "1.0.2",
+  "publishedAt": 1774857600
 }

--- a/crypto-com-app/scripts/fiat.ts
+++ b/crypto-com-app/scripts/fiat.ts
@@ -1,0 +1,212 @@
+import readline from "node:readline";
+import { apiGet, apiPost, assertOk } from "./lib/api.js";
+import { ErrorCode, fail, run, success } from "./lib/output.js";
+
+// ---------------------------------------------------------------------------
+// Helper: TOTP prompt
+// ---------------------------------------------------------------------------
+
+async function promptTotp(): Promise<string> {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stderr });
+    return new Promise((resolve) => {
+        rl.question("TOTP code required. Enter your 6-digit authenticator code: ", (answer) => {
+            rl.close();
+            resolve(answer.trim());
+        });
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
+
+async function discover() {
+    const accountRes = await apiGet("/v1/fiat-account");
+    assertOk(accountRes, "Fiat account fetch");
+
+    const balances: any[] = accountRes.data.account?.balances ?? [];
+    if (balances.length === 0) {
+        success({ currencies: [] });
+        return;
+    }
+
+    const currencies = [];
+    for (const bal of balances) {
+        const ccy = bal.currency;
+        const balance = bal.amount?.amount ?? "0";
+
+        const netRes = await apiGet(`/v1/fiat/payment-networks?currency=${encodeURIComponent(ccy)}`);
+        if (netRes.status !== 200 || netRes.data.ok !== true) {
+            currencies.push({ currency: ccy, balance, deposit: [], withdrawal: [] });
+            continue;
+        }
+
+        const networks: any[] = netRes.data.available_payment_networks ?? [];
+        const net = networks.find((n: any) => n.currency === ccy);
+        if (!net) {
+            currencies.push({ currency: ccy, balance, deposit: [], withdrawal: [] });
+            continue;
+        }
+
+        currencies.push({
+            currency: ccy,
+            balance,
+            deposit: net.deposit_push_payment_networks ?? [],
+            withdrawal: net.withdrawal_payment_networks ?? [],
+        });
+    }
+
+    success({ currencies });
+}
+
+async function paymentNetworks(currency: string) {
+    if (!currency) {
+        fail(ErrorCode.INVALID_ARGS, "Currency required. Example: npx tsx scripts/fiat.ts payment-networks USD");
+    }
+
+    const res = await apiGet(`/v1/fiat/payment-networks?currency=${encodeURIComponent(currency)}`);
+    assertOk(res, `Payment networks fetch for ${currency}`);
+
+    success(res.data.available_payment_networks);
+}
+
+async function depositMethods(currency: string, depositMethod: string) {
+    if (!currency) {
+        fail(ErrorCode.INVALID_ARGS, "Currency required. Example: npx tsx scripts/fiat.ts deposit-methods USD sepa");
+    }
+    if (!depositMethod) {
+        fail(ErrorCode.INVALID_ARGS, "Deposit method required. Example: npx tsx scripts/fiat.ts deposit-methods USD sepa");
+    }
+
+    const res = await apiGet(
+        `/v1/fiat/deposit-methods?currency=${encodeURIComponent(currency)}&deposit_method=${encodeURIComponent(depositMethod)}`,
+    );
+    assertOk(res, `Deposit methods fetch for ${currency} ${depositMethod}`);
+
+    success(res.data.deposit_methods);
+}
+
+async function emailDepositInfo(currency: string, vibanType: string) {
+    if (!currency) {
+        fail(ErrorCode.INVALID_ARGS, "Currency required. Example: npx tsx scripts/fiat.ts email-deposit-info USD iban");
+    }
+    if (!vibanType) {
+        fail(ErrorCode.INVALID_ARGS, "VIBAN type required. Example: npx tsx scripts/fiat.ts email-deposit-info USD iban");
+    }
+
+    const res = await apiPost("/v1/fiat/deposit-info/email", {
+        currency,
+        viban_type: vibanType,
+    });
+    assertOk(res, `Email deposit info for ${currency} ${vibanType}`);
+
+    success(res.data.bank_info_email);
+}
+
+async function withdrawalDetails(currency: string, vibanType: string) {
+    if (!currency) {
+        fail(ErrorCode.INVALID_ARGS, "Currency required. Example: npx tsx scripts/fiat.ts withdrawal-details USD iban");
+    }
+    if (!vibanType) {
+        fail(ErrorCode.INVALID_ARGS, "VIBAN type required. Example: npx tsx scripts/fiat.ts withdrawal-details USD iban");
+    }
+
+    const res = await apiGet(
+        `/v1/fiat/withdrawal-details?currency=${encodeURIComponent(currency)}&viban_type=${encodeURIComponent(vibanType)}`,
+    );
+    assertOk(res, `Withdrawal details fetch for ${currency} ${vibanType}`);
+
+    success(res.data.details);
+}
+
+async function createWithdrawalOrder(paramsJson: string) {
+    if (!paramsJson) {
+        fail(
+            ErrorCode.INVALID_ARGS,
+            `JSON params required. Example: npx tsx scripts/fiat.ts create-withdrawal-order '{"currency":"USD","amount":"100","viban_type":"iban"}'`,
+        );
+    }
+
+    let params: any;
+    try {
+        params = JSON.parse(paramsJson);
+    } catch {
+        fail(ErrorCode.INVALID_ARGS, `Invalid JSON: ${paramsJson}`);
+    }
+
+    if (!params.currency || !params.amount || !params.viban_type) {
+        fail(ErrorCode.INVALID_ARGS, "Required fields: currency, amount, viban_type");
+    }
+
+    const res = await apiPost("/v1/fiat/withdrawal-orders", params);
+    assertOk(res, "Withdrawal order creation");
+
+    success(res.data.viban_withdrawal_order);
+}
+
+async function createWithdrawal(orderId: string) {
+    if (!orderId) {
+        fail(ErrorCode.INVALID_ARGS, "Order ID required. Example: npx tsx scripts/fiat.ts create-withdrawal <order-id>");
+    }
+
+    let res = await apiPost("/v1/fiat/withdrawals", { order_id: orderId });
+
+    // Check for TOTP requirement
+    if (res.data?.error === "totp_required") {
+        const otp = await promptTotp();
+        res = await apiPost("/v1/fiat/withdrawals", { order_id: orderId, otp });
+    }
+
+    assertOk(res, "Withdrawal creation");
+
+    success(res.data.viban_withdrawal);
+}
+
+async function bankAccounts(currency?: string) {
+    const path = currency ? `/v1/fiat/bank-accounts?currency=${encodeURIComponent(currency)}` : "/v1/fiat/bank-accounts";
+    const res = await apiGet(path);
+    assertOk(res, currency ? `Bank accounts fetch for ${currency}` : "Bank accounts fetch");
+
+    success(res.data.bank_accounts);
+}
+
+// ---------------------------------------------------------------------------
+// CLI router
+// ---------------------------------------------------------------------------
+
+const USAGE = `Usage: npx tsx scripts/fiat.ts <command> [args]
+
+Commands:
+  discover                                       Cash overview (balances + payment networks)
+  payment-networks <currency>                    Available deposit/withdrawal networks
+  deposit-methods <currency> <deposit_method>    Bank details for a deposit method
+  email-deposit-info <currency> <viban_type>     Email deposit instructions to user
+  withdrawal-details <currency> <viban_type>     Withdrawal quotas, fees, minimums
+  create-withdrawal-order '<json>'               Create withdrawal order
+  create-withdrawal <order_id>                   Execute withdrawal (may prompt for TOTP)
+  bank-accounts [currency]                       List linked bank accounts`;
+
+run(async () => {
+    const [command, arg1, arg2] = process.argv.slice(2);
+
+    switch (command) {
+        case "discover":
+            return discover();
+        case "payment-networks":
+            return paymentNetworks(arg1);
+        case "deposit-methods":
+            return depositMethods(arg1, arg2);
+        case "email-deposit-info":
+            return emailDepositInfo(arg1, arg2);
+        case "withdrawal-details":
+            return withdrawalDetails(arg1, arg2);
+        case "create-withdrawal-order":
+            return createWithdrawalOrder(arg1);
+        case "create-withdrawal":
+            return createWithdrawal(arg1);
+        case "bank-accounts":
+            return bankAccounts(arg1);
+        default:
+            fail(ErrorCode.INVALID_ARGS, command ? `Unknown command "${command}".\n\n${USAGE}` : USAGE);
+    }
+});

--- a/crypto-com-app/scripts/lib/api.ts
+++ b/crypto-com-app/scripts/lib/api.ts
@@ -45,7 +45,8 @@ interface ApiResponse {
 }
 
 async function request(method: string, path: string, body?: unknown): Promise<ApiResponse> {
-    const headers = getSignedHeaders(method, path, body);
+    const signPath = path.split("?")[0];
+    const headers = getSignedHeaders(method, signPath, body);
     const url = `${BASE_URL}${path}`;
 
     const res = await fetch(url, {


### PR DESCRIPTION
  ## Summary

  - **HMAC signing fix** — Strip query string before signing GET requests. Without
  this, all endpoints with query params fail.
  - **`fiat.ts` script** — 8 new CLI commands for cash management: `discover`,
  `payment-networks`, `deposit-methods`, `email-deposit-info`, `withdrawal-details`,
  `create-withdrawal-order`, `create-withdrawal` (with TOTP support), `bank-accounts`
  - **SKILL.md** — Added Cash Commands section, Section 8 (Cash Deposit & Withdrawal)
  logic & rules, fiat error codes, currency/bank account disambiguation, fiat vs
  crypto balance routing
  - **Docs** — Updated AGENTS.md and README.md with fiat capabilities
  - **Version** — Bumped to 1.0.2

  ## Test plan

  - [x] Verify `npx tsx scripts/fiat.ts` prints usage
  - [x] Run fiat commands against production with valid API key
  - [x] Verify HMAC signing fix doesn't break existing trading/account scripts