### PR TITLE
feat: update crypto-com-exchange skill to use cdcx-cli

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,20 +2,9 @@
   "name": "crypto-agent-trading",
   "version": "1.0.1",
   "description": "Agent skills for trading cryptocurrency via Crypto.com APIs. Provides two independent skills: Crypto.com App for buy/sell/swap operations and Crypto.com Exchange for spot trading with advanced order types.",
-  "author": "Crypto.com",
+  "author": { "name": "Crypto.com" },
   "homepage": "https://github.com/crypto-com/crypto-agent-trading",
   "keywords": ["crypto", "trading", "cryptocurrency", "api", "bitcoin", "ethereum", "finance"],
   "repository": "https://github.com/crypto-com/crypto-agent-trading",
-  "skills": [
-    {
-      "name": "crypto-com-app",
-      "description": "Buy, sell, and swap cryptocurrency via the Crypto.com App API. Supports 400+ tokens with portfolio management and trading limits.",
-      "directory": "crypto-com-app"
-    },
-    {
-      "name": "crypto-com-exchange",
-      "description": "Spot trading on Crypto.com Exchange with advanced order types (limit, market, stop-loss, OCO) and market data access.",
-      "directory": "crypto-com-exchange"
-    }
-  ]
+  "skills": "./"
 }

--- a/crypto-com-exchange/README.md
+++ b/crypto-com-exchange/README.md
@@ -38,7 +38,7 @@ This skill delegates all API interaction to the `cdcx` CLI binary, which handles
 npx @cryptocom/cdcx-cli@latest --version
 
 # 2. Authenticate
-cdcx setup
+cdcx auth login --oauth
 
 # 3. Verify
 cdcx account summary -o json

--- a/crypto-com-exchange/README.md
+++ b/crypto-com-exchange/README.md
@@ -1,38 +1,51 @@
-# Crypto.com Exchange Spot Skill
+# Crypto.com Exchange Skill
 
-AI agent skill for trading on Crypto.com Exchange Spot markets via REST API.
+AI agent skill for trading on Crypto.com Exchange via the [`cdcx` CLI](https://github.com/crypto-com/cdcx-cli).
 
 ## What This Skill Does
 
 Gives your AI agent the ability to:
-- Place, amend, and cancel spot orders (LIMIT, MARKET)
+- Fetch market data (prices, orderbook, candles, instruments) — no auth needed
+- Place, amend, and cancel spot and derivatives orders (LIMIT, MARKET)
 - Create advanced orders (STOP_LOSS, STOP_LIMIT, TAKE_PROFIT, TAKE_PROFIT_LIMIT)
-- Manage OCO, OTO, and OTOCO order groups
+- Manage OCO, OTO, and OTOCO bracket order groups
 - Query balances, positions, order history, and trade history
 - Withdraw funds and check deposit/withdrawal status
-- Read market data (tickers, order book, candlesticks, trades)
+- Paper trade with live market prices (no auth, no risk)
+- Stream real-time market data via WebSocket
+
+## How It Works
+
+This skill delegates all API interaction to the `cdcx` CLI binary, which handles:
+- Authentication and HMAC-SHA256 request signing
+- Safety tier enforcement (read / sensitive_read / mutate / dangerous)
+- Dry-run previews before live execution
+- Output formatting (JSON, table, NDJSON)
+- Rate limit awareness
 
 ## Files
 
 | File | Purpose |
 |------|---------|
-| `SKILL.md` | Main skill definition — 52 endpoints, parameters, edge cases, agent behavior |
-| `references/authentication.md` | HMAC-SHA256 signing implementation (Python, JavaScript, Bash), error codes |
-| `LICENSE.md` | MIT License |
+| `SKILL.md` | Main skill definition — capabilities, commands, workflows, agent behavior |
+| `references/install.md` | Installation methods (npm, curl, cargo, plugin) |
+| `references/authentication.md` | Credential setup, profiles, environments, error codes |
 
-## Setup
+## Quick Start
 
-1. Install the skill files into your agent
-2. Provide your Crypto.com Exchange API key and secret
-3. The agent handles authentication, signing, and request formatting automatically
+```bash
+# 1. Install
+npx @cryptocom/cdcx-cli@latest --version
 
-### Getting API Keys
+# 2. Authenticate
+cdcx setup
 
-1. Log in to [Crypto.com Exchange](https://crypto.com/exchange)
-2. Go to **Settings → API Keys**
-3. Create a new key with desired permissions (Spot Trading, Withdrawal, etc.)
-4. Set IP whitelist for production use
-5. Store the API key and secret securely
+# 3. Verify
+cdcx account summary -o json
+
+# 4. Trade
+cdcx trade order BUY BTC_USDT 0.01 --type LIMIT --price 50000 --dry-run -o json
+```
 
 ## Environments
 
@@ -41,23 +54,12 @@ Gives your AI agent the ability to:
 | Production | `https://api.crypto.com/exchange/v1/` |
 | UAT Sandbox | `https://uat-api.3ona.co/exchange/v1/` |
 
-UAT Sandbox requires separate credentials (institutional access only).
-
 ## Coverage
 
-- **52 endpoints** — public market data, private trading, advanced orders, wallet, account management
-- **Production-tested** — every endpoint verified against live API with real orders
-- **66 edge cases documented** — param types, pagination quirks, error codes, validation rules
-
-## Key Things Your Agent Should Know
-
-- Order params (`price`, `quantity`, `notional`, `ref_price`, `amount`) must be **strings**
-- `limit` must be a **number** (not string)
-- Instrument names are case-sensitive: `BTC_USD` not `btc_usd`
-- Public endpoints = GET only, Private endpoints = POST only
-- All private requests use JSON body with HMAC-SHA256 signature
-
-See `SKILL.md` for the full reference.
+- **86+ endpoints** via OpenAPI-driven CLI (auto-discovered, always current)
+- **Safety tiers** — read-only by default, opt-in for mutations
+- **Paper trading** — test strategies without real funds
+- **Streaming** — real-time WebSocket data
 
 ## License
 

--- a/crypto-com-exchange/SKILL.md
+++ b/crypto-com-exchange/SKILL.md
@@ -1,638 +1,319 @@
 ---
 name: crypto-com-exchange
-description: Crypto.com Exchange Spot request using the Crypto.com Exchange API. Authentication requires API key and secret key. Supports production and UAT sandbox.
+description: Trade on Crypto.com Exchange — market data, spot/derivatives orders, portfolio management, wallet operations. Uses cdcx CLI for execution with built-in auth, safety tiers, and dry-run.
 metadata:
-  version: 1.0.1
+  version: 2.0.0
   author: Crypto.com
+  openclaw:
+    requires:
+      bins: [cdcx]
+    install:
+      - kind: node
+        package: '@cryptocom/cdcx-cli'
+        bins: [cdcx]
+        label: Install cdcx CLI (npm)
 license: MIT
 ---
 
-# Crypto.com Exchange Spot Skill
+# Crypto.com Exchange Skill
 
-Spot request on Crypto.com Exchange using authenticated API endpoints. Requires API key and secret key for private endpoints. Return the result in JSON format.
+Trade on Crypto.com Exchange using the `cdcx` CLI. Covers spot, derivatives, advanced orders, portfolio, and wallet operations.
 
-## Quick Reference
+## Prerequisites
 
-| Endpoint | Method | Description | Required | Optional | Authentication |
-|----------|--------|-------------|----------|----------|----------------|
-| `public/get-instruments` (GET) | GET | List all supported instruments | None | None | No |
-| `public/get-book` (GET) | GET | Order book for an instrument | instrument_name, depth | None | No |
-| `public/get-candlestick` (GET) | GET | Candlestick/OHLCV data | instrument_name | timeframe, count, start_ts, end_ts | No |
-| `public/get-trades` (GET) | GET | Recent public trades | instrument_name | count, start_ts, end_ts | No |
-| `public/get-tickers` (GET) | GET | Ticker information | None | instrument_name | No |
-| `public/get-valuations` (GET) | GET | Valuation data (index/mark price) | instrument_name, valuation_type | count, start_ts, end_ts | No |
-| `public/get-expired-settlement-price` (GET) | GET | Expired settlement prices | instrument_type | page (must be ≥1) | No |
-| `public/get-insurance` (GET) | GET | Insurance fund balance | instrument_name | count, start_ts, end_ts | No |
-| `public/get-announcements` (GET) | GET | Exchange announcements (base: `https://api.crypto.com/v1/`) | None | category, product_type | No |
-| `public/get-risk-parameters` (GET) | GET | Risk parameters for margin | None | None | No |
-| `private/create-order` (POST) | POST | Place a new order | instrument_name, side, type | price, quantity, notional, client_oid, exec_inst, time_in_force, spot_margin, stp_scope, stp_inst, stp_id, fee_instrument_name, isolation_id, leverage, isolated_margin_amount | Yes |
-| `private/create-order-list` (POST) | POST | Batch order creation (1-10, LIST only) | contingency_type, order_list | Per-order params | Yes |
-| `private/amend-order` (POST) | POST | Modify an existing order | new_price, new_quantity | order_id, orig_client_oid, client_oid | Yes |
-| `private/cancel-order` (POST) | POST | Cancel a single order | order_id or client_oid | None | Yes |
-| `private/cancel-order-list` (POST) | POST | Batch cancel orders | contingency_type, order_list | None | Yes |
-| `private/cancel-all-orders` (POST) | POST | Cancel all orders | None | instrument_name, type | Yes |
-| `private/close-position` (POST) | POST | Close an open position | instrument_name, type | price, quantity, isolation_id | Yes |
-| `private/get-open-orders` (POST) | POST | List ALL active open orders | None | instrument_name | Yes |
-| `private/get-order-detail` (POST) | POST | Query specific order | order_id or client_oid | None | Yes |
-| `private/get-order-history` (POST) | POST | Historical orders | None | instrument_name, start_time, end_time, limit, isolation_id | Yes |
-| `private/get-trades` (POST) | POST | Account trade list | None | instrument_name, start_time, end_time, limit, isolation_id | Yes |
-| `private/get-transactions` (POST) | POST | Transaction journal (trading, settlement, funding) | None | instrument_name, journal_type, start_time, end_time, limit, isolation_id | Yes |
-| `private/user-balance` (POST) | POST | Current wallet balances | None | None | Yes |
-| `private/user-balance-history` (POST) | POST | Historical balance snapshots | None | timeframe, end_time, limit | Yes |
-| `private/get-accounts` (POST) | POST | Master/sub-account info | None | page_size, page | Yes |
-| `private/get-subaccount-balances` (POST) | POST | All sub-account balances | None | None | Yes |
-| `private/get-positions` (POST) | POST | Active positions | None | instrument_name | Yes |
-| `private/create-subaccount-transfer` (POST) | POST | Transfer between accounts | from, to, currency, amount | None | Yes |
-| `private/get-fee-rate` (POST) | POST | Trading fee structure | None | None | Yes |
-| `private/get-instrument-fee-rate` (POST) | POST | Fee rate by instrument | instrument_name | None | Yes |
-| `private/change-account-leverage` (POST) | POST | Adjust account leverage | account_id, leverage | None | Yes |
-| `private/change-account-settings` (POST) | POST | Update account settings | None | stp_scope, stp_inst, stp_id, leverage | Yes |
-| `private/get-account-settings` (POST) | POST | Retrieve account config | None | None | Yes |
-| `private/create-withdrawal` (POST) | POST | Create a withdrawal | currency, amount, address | client_wid, address_tag, network_id | Yes |
-| `private/get-deposit-address` (POST) | POST | Get deposit address | currency | None | Yes |
-| `private/get-currency-networks` (POST) | POST | Get currency network info | None | None | Yes |
-| `private/get-deposit-history` (POST) | POST | Get deposit history | None | currency, start_ts, end_ts, page_size, page, status | Yes |
-| `private/get-withdrawal-history` (POST) | POST | Get withdrawal history | None | currency, start_ts, end_ts, page_size, page, status | Yes |
-| `private/advanced/create-order` (POST) | POST | Create trigger/stop/TP order | instrument_name, side, type, quantity | price, ref_price, client_oid, time_in_force, exec_inst, stp_scope, stp_inst, stp_id, fee_instrument_name | Yes |
-| `private/advanced/create-oco` (POST) | POST | Create OCO order (2 orders) | order_list (2 orders) | Per-order params | Yes |
-| `private/advanced/cancel-oco` (POST) | POST | Cancel OCO order | list_id | None | Yes |
-| `private/advanced/create-oto` (POST) | POST | Create OTO order (2 orders) | order_list (2 orders) | Per-order params | Yes |
-| `private/advanced/cancel-oto` (POST) | POST | Cancel OTO order | list_id | None | Yes |
-| `private/advanced/create-otoco` (POST) | POST | Create OTOCO order (3 orders) | order_list (3 orders) | Per-order params | Yes |
-| `private/advanced/cancel-otoco` (POST) | POST | Cancel OTOCO order | list_id | None | Yes |
-| `private/advanced/cancel-order` (POST) | POST | Cancel individual OTO/OTOCO leg | order_id or client_oid | None | Yes |
-| `private/advanced/cancel-all-orders` (POST) | POST | Cancel all advanced orders | None | instrument_name, type | Yes |
-| `private/advanced/get-open-orders` (POST) | POST | List open advanced orders | None | instrument_name | Yes |
-| `private/advanced/get-order-detail` (POST) | POST | Query advanced order detail | order_id or client_oid | None | Yes |
-| `private/advanced/get-order-history` (POST) | POST | Advanced order history | None | instrument_name, start_time, end_time, limit | Yes |
+1. Install: `npx @cryptocom/cdcx-cli@latest` or see [references/install.md](./references/install.md)
+2. Authenticate: run `cdcx auth login --oauth` — opens browser for OAuth, no manual key entry needed
+3. Verify: `cdcx account summary -o json`
 
----
+If `cdcx account summary` fails with "No credentials found", immediately execute `cdcx auth login --oauth` via Bash (with ~120s timeout for browser callback).
 
-## Parameters
 
-### Common Parameters
+## Capabilities
 
-* **instrument_name**: Instrument name. Spot pairs use underscore format (e.g., `BTC_USD`, `ETH_USDT`, `CRO_USD`). **Case-sensitive** — `btc_usd` will not work
-* **side**: Order side — `BUY` or `SELL`
-* **type**: Order type — `LIMIT` or `MARKET`
-* **quantity**: Order quantity (string, e.g., `"0.01"`)
-* **notional**: Order value in quote currency (for MARKET BUY orders, use instead of quantity)
-* **price**: Limit price (string, required for LIMIT orders, e.g., `"50000.00"`)
-* **client_oid**: Optional client-assigned order ID (max 36 characters)
-* **time_in_force**: Order duration policy
-* **exec_inst**: Execution instructions (array)
-* **stp_scope**: Self-trade prevention scope
-* **stp_inst**: Self-trade prevention instruction
-* **stp_id**: Self-trade prevention ID (0 to 32767)
-* **fee_instrument_name**: Instrument to use for fee payment
-* **spot_margin**: `SPOT` (default) or `MARGIN`
-* **isolation_id**: Isolated margin position ID
-* **leverage**: Leverage multiplier
-* **isolated_margin_amount**: Amount for isolated margin
-* **depth**: Order book depth. Must be ≥1 (e.g., 10, 50, 150). No hard upper limit — returns available levels
-* **timeframe**: Candlestick interval
-* **count**: Number of results to return. Max: 300 for candlestick, 150 for public trades. Min: 1 (0 → error 40004)
-* **start_ts**: Start timestamp in Unix ms (used for public endpoints and wallet history)
-* **end_ts**: End timestamp in Unix ms (used for public endpoints and wallet history)
-* **start_time**: Start time in Unix time format, inclusive (used for trading history endpoints — `get-order-history`, `get-trades`, `get-transactions`). Nanosecond recommended for accurate pagination
-* **end_time**: End time in Unix time format, exclusive (used for trading history endpoints). Nanosecond recommended for accurate pagination
-* **limit**: Maximum number of records. Default: 100. Max: 100 (for trading history endpoints)
-* **page_size**: Results per page. Default: 20. Max: 200. **Only works on wallet history endpoints** (`get-deposit-history`, `get-withdrawal-history`). Ignored on trading endpoints (`get-order-history`, `get-trades`, `get-open-orders`) — use `limit` instead
-* **page**: Page number (0-based)
-* **new_price**: New price for amend-order (required, must always be provided even if unchanged)
-* **new_quantity**: New quantity for amend-order (required, must always be provided even if unchanged)
-* **orig_client_oid**: Original client order ID for amend-order (alternative to order_id)
-* **ref_price**: Trigger/reference price for advanced orders (used with STOP_LOSS, STOP_LIMIT, TAKE_PROFIT, TAKE_PROFIT_LIMIT)
-* **ref_price_type**: Reference price type — only `MARK_PRICE` supported for OCO/OTO/OTOCO trigger legs
-* **contingency_type**: `LIST` for batch orders via `create-order-list` (OCO/OTO/OTOCO are **NOT** supported on this endpoint — returns 140001 API_DISABLED). Use `private/advanced/create-oco`, `create-oto`, `create-otoco` instead
-* **order_list**: Array of order objects for batch/advanced order creation
-* **list_id**: ID for OCO/OTO/OTOCO order groups (returned on creation, used for cancellation)
-* **leg_id**: Leg identifier within OTO/OTOCO (1, 2, or 3)
+| Domain | CLI Group | What It Does |
+|--------|-----------|--------------|
+| Market Data | `cdcx market` | Prices, orderbook, candles, trades, instruments — no auth needed |
+| Order Execution | `cdcx trade` | Place/amend/cancel LIMIT and MARKET orders |
+| Advanced Orders | `cdcx advanced` | OCO, OTO, OTOCO bracket orders with trigger logic |
+| Portfolio | `cdcx account` | Balances, positions, sub-accounts, P&L |
+| History | `cdcx history` | Order history, fills, transactions |
+| Wallet | `cdcx wallet` | Deposits, withdrawals, network info |
+| Margin | `cdcx margin` | Isolated margin transfers, leverage |
+| Staking | `cdcx staking` | Stake/unstake, conversion, reward history |
+| Fiat | `cdcx fiat` | Fiat deposit/withdrawal, bank accounts |
+| Paper Trading | `cdcx paper` | Local simulation with live prices, no auth |
+| Streaming | `cdcx stream` | Real-time WebSocket data (NDJSON) |
 
-### Wallet Parameters
+## Safety Model
 
-* **currency**: Currency symbol (e.g., `BTC`, `CRO`, `USDT`)
-* **amount**: Amount as string (e.g., `"1"`)
-* **address**: Withdrawal destination address
-* **address_tag**: Secondary address identifier for coins like XRP, XLM (also known as memo or tag)
-* **network_id**: Desired network for withdrawal. Must be whitelisted first. See `get-currency-networks` for values
-* **client_wid**: Optional client withdrawal ID
-* **status**: Filter by status. Deposit: `0` (Not Arrived), `1` (Arrived), `2` (Failed), `3` (Pending). Withdrawal: `0` (Pending), `1` (Processing), `2` (Rejected), `3` (Payment In-progress), `4` (Payment Failed), `5` (Completed), `6` (Cancelled)
-* **journal_type**: Transaction journal type filter. Values: `TRADING`, `SESSION_SETTLE`, `FUNDING`, etc.
+Every command has a safety tier. The CLI enforces these automatically:
 
-### Request Envelope Parameters (all requests)
+| Tier | Behavior | Examples |
+|------|----------|----------|
+| `read` | Runs freely | `cdcx market ticker`, `cdcx market book` |
+| `sensitive_read` | Runs freely (auth required) | `cdcx account summary`, `cdcx trade open-orders` |
+| `mutate` | Requires `--yes` or MCP `acknowledged=true` | `cdcx trade order`, `cdcx trade amend` |
+| `dangerous` | Requires `--allow-dangerous` on MCP server | `cdcx trade cancel-all`, `cdcx wallet withdraw` |
 
-* **id**: Request identifier (integer, 0 to 9,223,372,036,854,775,807)
-* **method**: API endpoint name (e.g., `"private/create-order"`)
-* **nonce**: Current timestamp in milliseconds
-* **params**: Parameters object (can be empty `{}`)
-* **api_key**: Your API key (private methods only)
-* **sig**: Digital signature (private methods only)
+Always use `--dry-run` before live orders to preview the request.
 
-### Enums
+## Quick Start
 
-* **type** (order): LIMIT | MARKET
-* **side**: BUY | SELL
-* **time_in_force**: GOOD_TILL_CANCEL | IMMEDIATE_OR_CANCEL | FILL_OR_KILL
-* **exec_inst**: POST_ONLY | SMART_POST_ONLY | ISOLATED_MARGIN (array, POST_ONLY and SMART_POST_ONLY cannot coexist)
-* **stp_scope**: M (master or sub account) | S (sub account only)
-* **stp_inst**: M (cancel maker) | T (cancel taker) | B (cancel both)
-* **spot_margin**: SPOT | MARGIN
-* **timeframe** (candlestick): 1m | 5m | 15m | 30m | 1h | 2h | 4h | 6h | 12h | 1D | 7D | 14D | 1M (legacy formats also accepted: M1, M5, M15, M30, H1, H2, H4, H12, D1, D7, D14)
-* **instrument_type**: PERPETUAL_SWAP | FUTURE
-* **valuation_type**: INDEX_PRICE | MARK_PRICE (context-dependent)
-* **contingency_type**: LIST (batch) | OTO | OTOCO (in responses)
-* **type** (advanced order): STOP_LOSS | STOP_LIMIT | TAKE_PROFIT | TAKE_PROFIT_LIMIT
-* **ref_price_type**: MARK_PRICE
-* **order status** (advanced open): NEW | PENDING | ACTIVE
-* **order status** (advanced history): REJECTED | CANCELED | FILLED | EXPIRED
+### Check Balance
 
-### Important Notes
-
-* **Must be strings**: `price`, `quantity`, `notional`, `ref_price`, `amount`, `new_price`, `new_quantity` — order/amount params must be strings (e.g., `"0.01"` not `0.01`). Sending as number returns errors: `price` → 308, `quantity` → 40101, `notional` → 50001, `ref_price` → 229
-* **Must be numbers**: `limit`, `end_time` (on `user-balance-history`) — must be integers. Sending `limit` as string returns error 40003 on `get-order-history`, `get-trades`, `get-transactions`, `user-balance-history`, `advanced/get-order-history`
-* **Accept both**: `page`, `page_size`, `count`, `depth`, `start_time`, `end_time` (on trading history), `start_ts`, `end_ts`
-
-### Production Validation Notes
-
-* **FAR_AWAY_LIMIT_PRICE (315)**: Limit orders with prices too far from market are rejected (e.g., BUY BTC @ $1 or SELL BTC @ $999,999). Keep limit prices within a reasonable range of current market price
-* **Expired settlement page**: `public/get-expired-settlement-price` requires `page >= 1`. Sending `page=0` returns error 40004. Omitting `page` entirely works (returns first page)
-* **Withdrawal whitelist**: `private/create-withdrawal` requires the destination address to be whitelisted in your **Exchange** withdrawal settings (not App). Non-whitelisted addresses return error 5000811 (WITHDRAW_ADDRESS_NOT_IN_WHITE_LIST)
-* **Withdrawal amount is gross**: `amount` includes the fee. If you send `amount: "11"` and the network fee is 1, the recipient gets 10. The response shows `amount: 10` and `fee: 1`
-* **Withdrawal network_id**: For multi-chain tokens (USDC, USDT, etc.), always specify `network_id`. Without it, the API may reject or pick an unexpected default chain
-* **MARKET order + price**: MARKET orders ignore `price` if provided (no error). For MARKET BUY, use `notional`. For MARKET SELL, use `quantity`
-* **POST_ONLY on MARKET**: Returns error 43005 (POST_ONLY_REJ). POST_ONLY only works with LIMIT orders
-* **FOK/IOC on far-from-market LIMIT**: `FILL_OR_KILL` and `IMMEDIATE_OR_CANCEL` on limit orders far from market will immediately reject (43003/43004) since they can't fill
-* **amend-order requires both**: Both `new_price` AND `new_quantity` must always be provided (even if one is unchanged). Omitting either returns 40004
-* **Batch order max**: `create-order-list` accepts maximum 10 orders. 11+ returns 40004
-* **HTTP methods are strict**: Public endpoints accept **GET only** (POST → 50001). Private endpoints accept **POST only** (GET → 40003)
-* **Amend cancelled/filled order**: Returns 212 (INVALID_ORDERID). Can only amend ACTIVE orders
-* **Unknown params are silently ignored**: Extra/unknown keys in `params` don't cause errors
-* **Inverted time range**: `start_time` > `end_time` does NOT error — the API appears to ignore ordering and returns data anyway
-* **cancel-all-orders scopes by instrument**: Only cancels orders for the specified `instrument_name`. Other instruments' orders are untouched
-* **Multiple STOP orders on same instrument**: Allowed — no limit on concurrent trigger orders per instrument
-* **OTO second leg must be trigger order**: The contingent (second) leg of an OTO must be STOP_LOSS, STOP_LIMIT, TAKE_PROFIT, or TAKE_PROFIT_LIMIT — not a plain LIMIT. Using LIMIT for the second leg returns 40004
-* **OTOCO structure**: Leg 1 = primary LIMIT order, Leg 2 = take-profit trigger, Leg 3 = stop-loss trigger. Legs 2 and 3 must be trigger order types
-* **MARKET BUY with both notional + quantity**: `quantity` takes priority over `notional`. If the quantity is below minimum, you get error 415 even if notional would be valid
-* **get-open-orders has NO pagination**: `page`, `page_size`, `count`, and `limit` params are all ignored — returns ALL open orders regardless
-* **get-order-history/get-trades pagination**: `limit` works correctly. `page`/`page_size` are **ignored** (always returns up to `limit`, default 100). Use `start_time`/`end_time` for windowed queries
-* **Nonce accepts int or string** — float is rejected (40101). `id` must be a number (string → 40001)
-* **Candlestick count max 300**: Requesting more silently caps at 300. `count=0` returns 40004. Min is 1
-* **Public trades count max 150**: Requesting more silently caps at 150
-* **get-instruments has no server-side filtering**: `inst_type`, `currency`, and other filter params are ignored — always returns ALL instruments (852+). Filter client-side
-* **order_id format**: Always a numeric string (e.g., `"6530219599901000701"`). Returned as string, accepted as string or number
-* **spot_margin values**: Only `"SPOT"` or `"MARGIN"` are valid. Invalid values → 50001. `"MARGIN"` requires margin access (error 416 without it)
-* **get-valuations requires both params**: Must provide `instrument_name` AND `valuation_type` (only `mark_price` works for spot pairs; `index_price` → 40004). Without `valuation_type` → 40003
-* **get-insurance requires instrument_name**: Not optional — omitting returns 40003
-* **Candlestick valid timeframes**: `1m`, `5m`, `15m`, `30m`, `1h`, `2h`, `4h`, `6h`, `12h`, `1D`, `7D`, `14D`, `1M`. Legacy format also works: `M1`, `M5`, `M15`, `M30`, `H1`, `H2`, `H4`, `H12`, `D1`, `D7`, `D14`. Invalid timeframes (e.g., `2m`, `8h`, `3D`) return 40003
-* Trading history endpoints (`get-order-history`, `get-trades`, `get-transactions`) use `start_time`/`end_time` with nanosecond precision recommended
-* Wallet history endpoints (`get-deposit-history`, `get-withdrawal-history`) use `start_ts`/`end_ts` in milliseconds
-* `notional` is used instead of `quantity` for MARKET BUY orders (specifies spend amount in quote currency)
-* For MARKET SELL orders, use `quantity` (amount of base currency to sell)
-* If you omit all parameters, you still need to pass an empty params block `params: {}` for API request consistency
-
----
-
-## Advanced Order Management API
-
-Advanced order types (trigger orders, OCO, OTO, OTOCO) are managed through the `private/advanced/*` endpoints. These are **Spot-only** for now.
-
-### private/advanced/create-order
-
-Creates a trigger order (STOP_LOSS, STOP_LIMIT, TAKE_PROFIT, TAKE_PROFIT_LIMIT).
-
-- `STOP_LIMIT` and `TAKE_PROFIT_LIMIT` execute a LIMIT order when `ref_price` is reached
-- `STOP_LOSS` and `TAKE_PROFIT` execute a MARKET order when `ref_price` is reached
-
-**Trigger direction:**
-- `ref_price` below market: SELL STOP_LOSS/STOP_LIMIT, BUY TAKE_PROFIT/TAKE_PROFIT_LIMIT
-- `ref_price` above market: BUY STOP_LOSS/STOP_LIMIT, SELL TAKE_PROFIT/TAKE_PROFIT_LIMIT
-
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| instrument_name | string | Y | e.g., BTC_USD |
-| side | string | Y | BUY, SELL |
-| type | string | Y | STOP_LOSS, STOP_LIMIT, TAKE_PROFIT, TAKE_PROFIT_LIMIT |
-| price | string | Depends | For STOP_LIMIT and TAKE_PROFIT_LIMIT only: limit price (e.g., `"0.12"`) |
-| quantity | string | Y | Order quantity (e.g., `"10"`) |
-| ref_price | string | N | Trigger price (e.g., `"0.12"`) |
-| client_oid | string | N | Client order ID (max 36 chars) |
-| time_in_force | string | N | GOOD_TILL_CANCEL (default), FILL_OR_KILL, IMMEDIATE_OR_CANCEL |
-| exec_inst | array | N | POST_ONLY, SMART_POST_ONLY (cannot coexist) |
-| stp_scope | string | N | M (master/sub) or S (sub only) |
-| stp_inst | string | N* | M (cancel maker), T (cancel taker), B (cancel both). Required if stp_scope is set |
-| stp_id | string | N | 0 to 32767 |
-| fee_instrument_name | string | N | Preferred fee token |
-
-```json
-{
-  "id": 6573,
-  "method": "private/advanced/create-order",
-  "params": {
-    "instrument_name": "CRO_USD",
-    "side": "SELL",
-    "type": "STOP_LIMIT",
-    "quantity": "10",
-    "price": "0.12",
-    "ref_price": "0.12",
-    "client_oid": "c5f682ed-7108-4f1c-b755-972fcdca0f02"
-  }
-}
+```
+cdcx account summary -o json
 ```
 
-Response: `{ "order_id": "5755600460443882762", "client_oid": "..." }`
+### Get Market Price
 
-### private/advanced/create-oco
-
-Creates a One-Cancels-the-Other order. When one leg is partially/fully executed, the other is automatically canceled. Exactly **2 orders** required: one LIMIT + one trigger (STOP_LOSS, STOP_LIMIT, TAKE_PROFIT, or TAKE_PROFIT_LIMIT).
-
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| order_list | array | Y | Exactly 2 orders. One must be LIMIT, other must be a trigger type |
-
-Each order in `order_list` follows `private/create-order` params. For `ref_price_type` of the trigger order, only `MARK_PRICE` is supported.
-
-```json
-{
-  "method": "private/advanced/create-oco",
-  "id": 123456789,
-  "nonce": 123456789000,
-  "params": {
-    "order_list": [
-      {
-        "instrument_name": "BTC_USD",
-        "quantity": "0.1",
-        "type": "LIMIT",
-        "price": "93000",
-        "side": "SELL"
-      },
-      {
-        "instrument_name": "BTC_USD",
-        "quantity": "0.1",
-        "type": "STOP_LOSS",
-        "ref_price": "80000",
-        "side": "SELL"
-      }
-    ]
-  }
-}
+```
+cdcx market ticker BTC_USDT -o json
 ```
 
-Response: `{ "list_id": 6498090546073120100 }`
+### Place a Limit Order
 
-### private/advanced/create-oto
+```
+# Preview first
+cdcx trade order BUY BTC_USDT 0.01 --type LIMIT --price 50000 --dry-run -o json
 
-Creates a One-Triggers-the-Other order. When the first order (LIMIT) is fully executed, the second order (trigger) takes effect. Exactly **2 orders** required. The trigger order must be on the **opposite side** of the working LIMIT order (e.g., BUY LIMIT + SELL STOP_LOSS, or SELL LIMIT + BUY STOP_LOSS).
-
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| order_list | array | Y | Exactly 2 orders. One LIMIT + one trigger type. Trigger must be opposite side |
-
-```json
-{
-  "method": "private/advanced/create-oto",
-  "id": 123456789,
-  "nonce": 123456789000,
-  "params": {
-    "order_list": [
-      {
-        "instrument_name": "BTC_USD",
-        "quantity": "0.1",
-        "type": "LIMIT",
-        "price": "93000",
-        "side": "BUY"
-      },
-      {
-        "instrument_name": "BTC_USD",
-        "quantity": "0.1",
-        "type": "STOP_LOSS",
-        "ref_price": "80000",
-        "side": "SELL"
-      }
-    ]
-  }
-}
+# Execute
+cdcx trade order BUY BTC_USDT 0.01 --type LIMIT --price 50000 --client-oid my-buy-001 -o json
 ```
 
-Response: `{ "list_id": 6498090546073120100 }`
+### Place a Market Order
 
-### private/advanced/create-otoco
-
-Creates a One-Triggers-a-One-Cancels-the-Other order. When the first LIMIT order is fully executed, two trigger orders take effect. When either trigger executes, the other is canceled. Exactly **3 orders** required: one LIMIT + one STOP_LOSS/STOP_LIMIT + one TAKE_PROFIT/TAKE_PROFIT_LIMIT. The trigger orders must be on the **opposite side** of the working LIMIT order.
-
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| order_list | array | Y | Exactly 3 orders. One LIMIT + one stop + one take-profit. Triggers must be opposite side |
-
-```json
-{
-  "method": "private/advanced/create-otoco",
-  "id": 123456789,
-  "nonce": 123456789000,
-  "params": {
-    "order_list": [
-      {
-        "instrument_name": "BTC_USD",
-        "quantity": "0.1",
-        "type": "LIMIT",
-        "price": "93000",
-        "side": "BUY"
-      },
-      {
-        "instrument_name": "BTC_USD",
-        "quantity": "0.1",
-        "type": "STOP_LOSS",
-        "ref_price": "80000",
-        "side": "SELL"
-      },
-      {
-        "instrument_name": "BTC_USD",
-        "quantity": "0.1",
-        "type": "TAKE_PROFIT",
-        "ref_price": "108000",
-        "side": "SELL"
-      }
-    ]
-  }
-}
+```
+cdcx trade order BUY BTC_USDT 0.01 --type MARKET -o json
 ```
 
-Response: `{ "list_id": 6498090546073120100 }`
+### Cancel an Order
 
-### private/advanced/cancel-oco, cancel-oto, cancel-otoco
-
-Cancel an OCO/OTO/OTOCO order group.
-
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| list_id | string | Y | List ID returned from create |
-
-```json
-{ "method": "private/advanced/cancel-oco", "id": 1234, "nonce": 123456789000, "params": { "list_id": "4421958062479290999" } }
+```
+cdcx trade cancel --order-id 123456789 -o json
+cdcx trade cancel --client-oid my-buy-001 -o json
 ```
 
-### private/advanced/cancel-order
+### Amend an Order
 
-Cancel an individual leg of an OTO/OTOCO order.
-
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| order_id | number or string | Depends | Either order_id or client_oid must be present. String format recommended |
-| client_oid | string | Depends | Either order_id or client_oid must be present |
-
-### private/advanced/cancel-all-orders
-
-Cancel all advanced orders for an instrument.
-
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| instrument_name | string | N | e.g., BTC_USD. Omit to cancel ALL instruments |
-| type | string | N | LIMIT, TRIGGER, or ALL |
-
-### private/advanced/get-open-orders
-
-Get all open advanced orders.
-
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| instrument_name | string | N | e.g., BTC_USD. Omit for all |
-
-**Response fields per order:** account_id, order_id, client_oid, order_type, time_in_force, side, exec_inst, quantity, limit_price, order_value, maker_fee_rate, taker_fee_rate, avg_price, cumulative_quantity, cumulative_value, cumulative_fee, status (NEW/PENDING/ACTIVE), order_date, instrument_name, fee_instrument_name, list_id, contingency_type (OTO/OTOCO), leg_id, create_time, create_time_ns, update_time
-
-### private/advanced/get-order-detail
-
-Get details for a specific advanced order.
-
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| order_id | number or string | Depends | String format recommended |
-| client_oid | string | Depends | Either order_id or client_oid required |
-
-**Response fields:** Same as get-open-orders, with status including: NEW, PENDING, REJECTED, ACTIVE, CANCELED, FILLED
-
-### private/advanced/get-order-history
-
-Get historical advanced orders.
-
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| instrument_name | string | N | Omit for all |
-| start_time | number or string | N | Unix timestamp (ns recommended). Default: end_time - 1 day |
-| end_time | number or string | N | Unix timestamp (ns recommended). Default: current time |
-| limit | int | N | Max results. Default: 100, Max: 100 |
-
-**Note:** If you omit all parameters, you still need to pass `params: {}` for API request consistency.
-
-**Response fields:** Same as get-open-orders, with status including: REJECTED, CANCELED, FILLED, EXPIRED
-
-**Note:** To detect partial fills, check for status `ACTIVE` with `cumulative_quantity > 0`.
-
----
-
-## Wallet API
-
-### private/create-withdrawal
-
-Creates a withdrawal request. Withdrawal setting must be enabled for your API Key. Withdrawal addresses must first be whitelisted in your account's Withdrawal Whitelist page.
-
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| currency | string | Y | e.g., BTC, CRO, USDT |
-| amount | string | Y | **Gross** amount to withdraw (fee is deducted from this). e.g., `"11"` with fee=1 sends 10 to destination |
-| address | string | Y | Destination address. Must be whitelisted in Exchange withdrawal settings |
-| client_wid | string | N | Optional client withdrawal ID (max 36 chars) |
-| address_tag | string | N | Secondary identifier for XRP, XLM, etc. (memo/tag) |
-| network_id | string | N | Network for multi-chain tokens (e.g., `"ARB"`, `"ETH"`, `"SOL"`). **Strongly recommended** for multi-chain currencies — use `get-currency-networks` to list available networks and fees |
-
-### private/get-deposit-address
-
-Get deposit addresses for a currency.
-
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| currency | string | Y | e.g., BTC, CRO |
-
-### private/get-currency-networks
-
-Get all supported currency networks including withdrawal fees, minimum amounts, and deposit/withdrawal status.
-
-No required parameters (pass empty `params: {}`).
-
-### private/get-deposit-history
-
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| currency | string | N | e.g., BTC, CRO |
-| start_ts | long | N | Default: 90 days from current timestamp |
-| end_ts | long | N | Default: current timestamp |
-| page_size | int | N | Page size (Default: 20, Max: 200) |
-| page | int | N | Page number (0-based) |
-| status | string | N | `0` (Not Arrived), `1` (Arrived), `2` (Failed), `3` (Pending) |
-
-**Note:** Works for master account only, not for sub-accounts.
-
-### private/get-withdrawal-history
-
-| Param | Type | Required | Description |
-|-------|------|----------|-------------|
-| currency | string | N | e.g., BTC, CRO |
-| start_ts | long | N | Default: 90 days from current timestamp |
-| end_ts | long | N | Default: current timestamp |
-| page_size | int | N | Page size (Default: 20, Max: 200) |
-| page | int | N | Page number (0-based) |
-| status | string | N | `0` (Pending), `1` (Processing), `2` (Rejected), `3` (Payment In-progress), `4` (Payment Failed), `5` (Completed), `6` (Cancelled) |
-
-**Note:** Works for master account only, not for sub-accounts.
-
----
-
-## Authentication
-
-For endpoints that require authentication (all `private/` methods), you will need to provide Crypto.com Exchange API credentials.
-
-Required credentials:
-
-* **apiKey**: Your Crypto.com Exchange API key (for request identification and header)
-* **secretKey**: Your Crypto.com Exchange API secret (for HMAC-SHA256 signing)
-
-Base URLs:
-
-| Environment | REST API | User WebSocket | Market WebSocket |
-|-------------|----------|----------------|------------------|
-| Production | `https://api.crypto.com/exchange/v1/{method}` | `wss://stream.crypto.com/exchange/v1/user` | `wss://stream.crypto.com/exchange/v1/market` |
-| UAT Sandbox | `https://uat-api.3ona.co/exchange/v1/{method}` | `wss://uat-stream.3ona.co/exchange/v1/user` | `wss://uat-stream.3ona.co/exchange/v1/market` |
-
-### Rate Limits
-
-| Endpoint Type | Limit |
-|---------------|-------|
-| `private/create-order`, `private/cancel-order`, `private/cancel-all-orders` | 15 requests per 100ms each |
-| `private/get-order-detail` | 30 requests per 100ms |
-| `private/get-trades` | 1 request per second |
-| `private/get-order-history` | 1 request per second |
-| All other private REST | 3 requests per 100ms each |
-| Public market data (`get-book`, `get-tickers`, `get-trades`, etc.) | 100 requests per second each (per IP) |
-| User API WebSocket | 150 requests per second |
-| Market Data WebSocket | 100 requests per second |
-
-### Open Order Limits
-
-| Condition | Limit |
-|-----------|-------|
-| Max open orders per trading pair per account/subaccount | 200 |
-| Max open orders across all pairs per account/subaccount | 1000 |
-
----
-
-## Security
-
-### Share Credentials
-
-Users can provide Crypto.com Exchange API credentials by sending a file where the content is in the following format:
-
-```bash
-abc123...xyz
-secret123...key
+```
+cdcx trade amend --order-id 123456789 --new-price 51000 --new-quantity 0.01 -o json
 ```
 
-### Never Display Full Secrets
+Both `--new-price` and `--new-quantity` are required — re-submit the original value for the field you don't want to change.
 
-When showing credentials to users:
-- **API Key:** Show first 5 + last 4 characters: `dG9rZ...8akf`
-- **Secret Key:** Always mask, show only last 5: `***...ws1eK`
+## Market Data (No Auth)
 
-Example response when asked for credentials:
 ```
-Account: main
-API Key: dG9rZ...8akf
-Secret: ***...ws1eK
-Environment: Production
-```
-
-### Listing Accounts
-
-When listing accounts, show names and environment only — never keys:
-```
-Crypto.com Exchange Accounts:
-* main (Production)
-* sandbox-dev (UAT Sandbox)
+cdcx market ticker BTC_USDT -o json          # Current price
+cdcx market ticker -o json                    # All instruments
+cdcx market book BTC_USDT --depth 10 -o json  # Orderbook
+cdcx market candlestick BTC_USDT --timeframe 1h --count 24 -o json  # OHLCV
+cdcx market trades BTC_USDT -o json           # Recent prints
+cdcx market instruments -o json               # All tradable pairs + tick sizes
 ```
 
-### Transactions in Production
+Supported timeframes: `1m, 5m, 15m, 30m, 1h, 4h, 6h, 12h, 1D, 7D, 14D, 1M`
 
-When performing transactions in production, always confirm with the user before proceeding by asking them to write "CONFIRM" to proceed.
+### Streaming (real-time)
 
----
-
-## Crypto.com Exchange Accounts
-
-### main
-- API Key: your_production_api_key
-- Secret: your_production_secret
-- Sandbox: false
-
-### sandbox-dev
-- API Key: your_sandbox_api_key
-- Secret: your_sandbox_secret
-- Sandbox: true
-
-### TOOLS.md Structure
-
-```bash
-## Crypto.com Exchange Accounts
-
-### main
-- API Key: abc123...xyz
-- Secret: secret123...key
-- Sandbox: false
-- Description: Primary trading account
-
-### sandbox-dev
-- API Key: test456...abc
-- Secret: testsecret...xyz
-- Sandbox: true
-- Description: Development/testing
+```
+cdcx stream ticker BTC_USDT ETH_USDT   # NDJSON to stdout
+cdcx stream book BTC_USDT
+cdcx stream trades BTC_USDT
 ```
 
----
+## Order Execution
+
+Positional args: `<side> <instrument> <quantity>`. Side is `BUY` or `SELL`.
+
+```
+# Limit order
+cdcx trade order BUY BTC_USDT 0.01 --type LIMIT --price 50000 -o json
+
+# Market order (buy by notional)
+cdcx trade order BUY BTC_USDT --type MARKET --notional 500 -o json
+
+# Batch (up to 10)
+cdcx trade order-list --order-list '[
+    {"instrument_name":"BTC_USDT","side":"BUY","type":"LIMIT","price":"49000","quantity":"0.01"},
+    {"instrument_name":"BTC_USDT","side":"BUY","type":"LIMIT","price":"48000","quantity":"0.01"}
+]' -o json
+
+# List open orders
+cdcx trade open-orders BTC_USDT -o json
+
+# Close a position
+cdcx trade close-position BTCUSD-PERP --type MARKET -o json
+```
+
+### Order Options
+
+| Flag | Purpose |
+|------|---------|
+| `--type` | `LIMIT` or `MARKET` |
+| `--price` | Limit price (string) |
+| `--notional` | Spend amount in quote currency (MARKET BUY) |
+| `--client-oid` | Your correlation ID (max 36 chars) |
+| `--time-in-force` | `GOOD_TILL_CANCEL`, `FILL_OR_KILL`, `IMMEDIATE_OR_CANCEL` |
+| `--exec-inst` | `POST_ONLY`, `SMART_POST_ONLY`, `REDUCE_ONLY`, `ISOLATED_MARGIN` |
+| `--dry-run` | Preview without executing |
+
+## Advanced Orders (OCO / OTO / OTOCO)
+
+### OTOCO Bracket (entry + stop-loss + take-profit)
+
+```
+cdcx advanced create-otoco '[
+    {"instrument_name":"BTC_USDT","side":"BUY","type":"LIMIT","price":"50000","quantity":"0.01"},
+    {"instrument_name":"BTC_USDT","side":"SELL","type":"STOP_LOSS","trigger_price":"48000","quantity":"0.01","ref_price_type":"MARK_PRICE"},
+    {"instrument_name":"BTC_USDT","side":"SELL","type":"TAKE_PROFIT","trigger_price":"55000","quantity":"0.01","ref_price_type":"MARK_PRICE"}
+]' --dry-run -o json
+```
+
+### OTO (entry + protection)
+
+```
+cdcx advanced create-oto '[
+    {"instrument_name":"BTC_USDT","side":"BUY","type":"LIMIT","price":"50000","quantity":"0.01"},
+    {"instrument_name":"BTC_USDT","side":"SELL","type":"STOP_LOSS","trigger_price":"48000","quantity":"0.01","ref_price_type":"MARK_PRICE"}
+]' -o json
+```
+
+### OCO (two-sided exit for existing position)
+
+```
+cdcx advanced oco '[
+    {"instrument_name":"BTC_USDT","side":"SELL","type":"LIMIT","price":"55000","quantity":"0.01"},
+    {"instrument_name":"BTC_USDT","side":"SELL","type":"STOP_LOSS","trigger_price":"48000","quantity":"0.01","ref_price_type":"MARK_PRICE"}
+]' -o json
+```
+
+### Single Trigger Order
+
+```
+cdcx advanced order BTCUSD-PERP --side SELL --type STOP_LOSS --quantity 0.01 --trigger-price 48000 --ref-price-type MARK_PRICE -o json
+```
+
+### Manage Advanced Orders
+
+```
+cdcx advanced open-orders BTC_USDT -o json
+cdcx advanced order-detail --order-id <id> -o json
+cdcx advanced cancel-otoco --list-id <list_id> -o json
+cdcx advanced cancel-oco --list-id <list_id> -o json
+cdcx advanced cancel-oto --list-id <list_id> -o json
+```
+
+## Portfolio & Account
+
+```
+cdcx account summary -o json                # Cash balances
+cdcx account positions -o json              # Open positions + unrealized P&L
+cdcx account info -o json                   # Master + sub-accounts
+cdcx account subaccount-balances -o json    # Per-sub-account
+cdcx account balance-history --timeframe D1 -o json  # Equity curve
+
+# Fee rates
+cdcx trade fee-rate -o json
+cdcx trade instrument-fee-rate --instrument-name BTC_USDT -o json
+
+# History
+cdcx history orders BTC_USDT --limit 50 -o json
+cdcx history trades BTC_USDT --limit 50 -o json
+cdcx history transactions --limit 100 -o json
+```
+
+## Wallet Operations
+
+```
+# Deposit
+cdcx wallet networks -o json                        # Supported networks
+cdcx wallet deposit-address BTC -o json             # Get address
+cdcx wallet deposit-history -o json                 # Track arrivals
+
+# Withdraw (dangerous tier)
+cdcx wallet withdraw BTC 0.1 <ADDRESS> --network-id BITCOIN --dry-run -o json
+cdcx wallet withdraw BTC 0.1 <ADDRESS> --network-id BITCOIN --client-wid my-wd-001 -o json
+cdcx wallet withdrawal-history -o json
+```
+
+Withdrawals require whitelisted addresses (configured in Exchange web GUI).
+
+## Isolated Margin
+
+For instruments that require isolated margin (e.g. `SPYUSD-PERP`, `NVDAUSD-PERP`):
+
+```
+cdcx trade order BUY SPYUSD-PERP 0.001 --type LIMIT --price 710.25 --exec-inst ISOLATED_MARGIN -o json
+
+# Fund/withdraw margin
+cdcx margin transfer --direction IN --amount 100 <ISOLATION_ID>
+cdcx margin transfer --direction OUT --amount 50 <ISOLATION_ID>
+
+# Adjust leverage
+cdcx margin leverage --leverage 5 <ISOLATION_ID>
+```
+
+Get `isolation_id` from `cdcx account positions -o json`.
+
+## Paper Trading (No Auth)
+
+```
+cdcx paper init --balance 50000
+cdcx paper buy BTC_USDT --quantity 0.01 -o json
+cdcx paper sell BTC_USDT --quantity 0.01 -o json
+cdcx paper positions -o json
+cdcx paper balance -o json
+cdcx paper history -o json
+cdcx paper reset --balance 100000
+```
+
+## Recipes
+
+### Morning Brief
+
+```
+cdcx market ticker -o json                          # Market snapshot
+cdcx account summary -o json                        # Cash
+cdcx account positions -o json                      # Open positions
+cdcx trade open-orders -o json                      # Pending orders
+cdcx advanced open-orders -o json                   # Advanced orders
+cdcx history trades --start-time $(date -v-1d +%s)000 -o json  # Yesterday's fills
+```
+
+### Emergency Flatten
+
+```
+cdcx trade cancel-all --yes -o json                 # Cancel all orders
+cdcx advanced cancel-all --yes -o json              # Cancel all advanced
+cdcx account positions -o json | \
+    jq -r '.data[].instrument_name' | \
+    while read i; do cdcx trade close-position "$i" --type MARKET --yes; done
+cdcx account positions -o json                      # Verify flat
+```
+
+## Important Notes
+
+- Instrument names are case-sensitive: `BTC_USDT` not `btc_usd`. Spot uses `_` (e.g. `BTC_USDT`), perps use `-PERP` (e.g. `BTC-PERP`)
+- Prices in the API are strings — cast to float/decimal before arithmetic
+- `c` in ticker response is a ratio, not percentage: `0.0257` means +2.57%
+- Always supply `--client-oid` for order correlation
+- `close-position` is async — verify with `cdcx account positions` afterwards
+- Advanced orders live in their own namespace — not visible in `cdcx trade open-orders`
+- Batch max is 10 orders per call
+- OTOCO structure: Leg 1 = entry LIMIT, Leg 2 = take-profit trigger, Leg 3 = stop-loss trigger
+- OTO second leg must be a trigger type (STOP_LOSS, STOP_LIMIT, TAKE_PROFIT, TAKE_PROFIT_LIMIT)
+- `get-open-orders` has no pagination — returns ALL open orders
+- Withdrawal amount is gross (fee deducted from it)
+- For memo coins (XRP, XLM, EOS), always include `--address-tag`
 
 ## Agent Behavior
 
-1. Credentials requested: Mask secrets (show last 5 chars only)
-2. Listing accounts: Show names and environment, never keys
-3. Account selection: Ask if ambiguous, default to main
-4. When doing a transaction in production, confirm with user before by asking to write "CONFIRM" to proceed
-5. New credentials: Prompt for name, environment
-6. Order params (`price`, `quantity`, `notional`, `ref_price`, `amount`) must be strings. `limit` must be a number. `page`/`page_size` accept both
-7. Always include `Content-Type: application/json` header
-
-## Adding New Accounts
-
-When user provides new credentials:
-
-* Ask for account name
-* Ask: Production or UAT Sandbox
-* Store in `TOOLS.md` with masked display confirmation
-
----
-
-## Signing Requests
-
-All private endpoints require HMAC-SHA256 signature.
-
-### Signature Process
-
-1. Sort `params` keys in ascending alphabetical order
-2. Concatenate all param keys and values into a single string (no delimiters): `key1value1key2value2...`
-   - For arrays: the key appears once, then each element's sorted key+value pairs are concatenated directly (**no array indices**)
-   - For `None`/`null` values: use the string `"null"`
-   - Recursion depth is limited to 3 levels
-3. Build the signing payload: `{method}{id}{api_key}{param_string}{nonce}`
-4. HMAC-SHA256 hash the payload using your secret key, output as hex string
-5. Include `sig` in the request body
-
-### User Agent Header
-
-Include `User-Agent` header with the following string: `crypto-com-exchange/1.0.1 (Skill)`
-
-See [`references/authentication.md`](./references/authentication.md) for implementation details.
+1. Always `--dry-run` before live orders on new strategies
+2. Confirm with user before any `mutate` tier action in production — ask for "CONFIRM"
+3. Never display full API secrets — mask credentials (first 5 + last 4 for key, last 5 only for secret)
+4. Default to `--output json` for programmatic consumption
+5. Use `cdcx market instruments` to verify tick sizes before placing orders
+6. Check `cdcx account summary` for available balance before order placement
+7. For streaming data, prefer `cdcx stream` over polling

--- a/crypto-com-exchange/SKILL.md
+++ b/crypto-com-exchange/SKILL.md
@@ -284,6 +284,8 @@ cdcx history trades --start-time $(date -v-1d +%s)000 -o json  # Yesterday's fil
 
 ### Emergency Flatten
 
+**Requires explicit user CONFIRM before execution — this cancels all orders and closes all positions at market.**
+
 ```
 cdcx trade cancel-all --yes -o json                 # Cancel all orders
 cdcx advanced cancel-all --yes -o json              # Cancel all advanced
@@ -302,7 +304,7 @@ cdcx account positions -o json                      # Verify flat
 - `close-position` is async — verify with `cdcx account positions` afterwards
 - Advanced orders live in their own namespace — not visible in `cdcx trade open-orders`
 - Batch max is 10 orders per call
-- OTOCO structure: Leg 1 = entry LIMIT, Leg 2 = take-profit trigger, Leg 3 = stop-loss trigger
+- OTOCO structure: Leg 1 = entry LIMIT, Leg 2 = stop-loss trigger, Leg 3 = take-profit trigger
 - OTO second leg must be a trigger type (STOP_LOSS, STOP_LIMIT, TAKE_PROFIT, TAKE_PROFIT_LIMIT)
 - `get-open-orders` has no pagination — returns ALL open orders
 - Withdrawal amount is gross (fee deducted from it)

--- a/crypto-com-exchange/references/authentication.md
+++ b/crypto-com-exchange/references/authentication.md
@@ -52,3 +52,5 @@ When running as an MCP server, credentials from `cdcx auth login --oauth` are us
   }
 }
 ```
+
+To enable dangerous-tier operations (cancel-all, withdrawals) via MCP, add `"--allow-dangerous"` to the args array. Only do this if you understand the risks.

--- a/crypto-com-exchange/references/authentication.md
+++ b/crypto-com-exchange/references/authentication.md
@@ -1,420 +1,54 @@
-# Crypto.com Exchange Authentication
+# Authentication
 
-All private endpoints require HMAC-SHA256 signed requests.
+The `cdcx` CLI handles all authentication automatically — signing, nonce generation, and credential persistence.
 
-## Base URLs
-
-| Environment | URL |
-|-------------|-----|
-| Production | `https://api.crypto.com/exchange/v1/{method}` |
-| UAT Sandbox | `https://uat-api.3ona.co/exchange/v1/{method}` |
-
-## Request Structure
-
-All requests (public and private) use the following JSON envelope:
-
-```json
-{
-  "id": 1,
-  "method": "private/create-order",
-  "api_key": "your_api_key",
-  "params": {
-    "instrument_name": "BTC_USDT",
-    "side": "BUY",
-    "type": "LIMIT",
-    "price": "50000.00",
-    "quantity": "0.001"
-  },
-  "sig": "generated_signature_hex",
-  "nonce": 1234567890123
-}
-```
-
-**Public endpoints** only require `id`, `method`, `params`, and `nonce`.
-**Private endpoints** additionally require `api_key` and `sig`.
-
-## Required Headers
-
-```
-Content-Type: application/json
-User-Agent: crypto-com-exchange/1.0.1 (Skill)
-```
-
-## Signing Process
-
-### Step 1: Sort Parameters
-
-Sort the keys in `params` alphabetically in ascending order.
-
-Example params:
-```json
-{
-  "instrument_name": "BTC_USDT",
-  "side": "BUY",
-  "type": "LIMIT",
-  "price": "50000.00",
-  "quantity": "0.001"
-}
-```
-
-Sorted keys: `instrument_name`, `price`, `quantity`, `side`, `type`
-
-### Step 2: Build Parameter String
-
-Concatenate each key with its value (no separators, no spaces):
-
-```
-instrument_nameBTC_USDTprice50000.00quantity0.001sideBUYtypeLIMIT
-```
-
-**For nested arrays/objects:** Recursively sort and concatenate. For arrays, concatenate each element's string representation directly (no index numbers). For objects within arrays, sort their keys and concatenate key+value pairs. For `None`/`null` values, use the string `"null"`.
-
-**For empty params `{}`:** The parameter string is empty `""`.
-
-**Example with array params** (`order_list`):
-```json
-{
-  "contingency_type": "LIST",
-  "order_list": [
-    {"instrument_name": "BTC_USDT", "side": "BUY", "type": "LIMIT", "price": "50000", "quantity": "0.1"},
-    {"instrument_name": "ETH_USDT", "side": "BUY", "type": "LIMIT", "price": "3000", "quantity": "1"}
-  ]
-}
-```
-Parameter string: `contingency_typeLISTorder_listinstrument_nameBTC_USDTprice50000quantity0.1sideBUYtypeLIMITinstrument_nameETH_USDTprice3000quantity1sideBUYtypeLIMIT`
-
-Note: The outer key `order_list` appears once, then each array element's sorted key-value pairs are concatenated directly — **no array indices**.
-
-### Step 3: Build Signing Payload
-
-Concatenate in this exact order:
-
-```
-{method}{id}{api_key}{param_string}{nonce}
-```
-
-Example:
-```
-private/create-order1your_api_keyinstrument_nameBTC_USDTprice50000.00quantity0.001sideBUYtypeLIMIT1234567890123
-```
-
-### Step 4: Generate Signature
-
-Create HMAC-SHA256 hash of the signing payload using your secret key, output as hex:
+## Login
 
 ```bash
-echo -n "private/create-order1your_api_keyinstrument_nameBTC_USDTprice50000.00quantity0.001sideBUYtypeLIMIT1234567890123" | \
-  openssl dgst -sha256 -hmac "your_secret_key"
+cdcx auth login --oauth
 ```
 
-### Step 5: Include Signature in Request
+Opens a browser for OAuth authentication. Credentials are persisted automatically across sessions.
 
-Add the hex signature as the `sig` field in the request body.
+If authentication fails or credentials are missing, you MUST immediately execute `cdcx auth login --oauth` via Bash tool. The command requires ~120s timeout as it waits for browser callback. Print the callback url to users
 
-## Complete Example
-
-### Bash
+## Verify
 
 ```bash
-#!/bin/bash
-API_KEY="your_api_key"
-SECRET_KEY="your_secret_key"
-BASE_URL="https://api.crypto.com/exchange/v1"
-
-# Get current timestamp in milliseconds
-NONCE=$(date +%s%3N)
-
-# Request ID
-ID=1
-
-# Method
-METHOD="private/create-order"
-
-# Build param string (keys sorted alphabetically, concatenated with values)
-PARAM_STRING="instrument_nameBTC_USDTprice50000.00quantity0.001sideBUYtypeLIMIT"
-
-# Build signing payload
-PAYLOAD="${METHOD}${ID}${API_KEY}${PARAM_STRING}${NONCE}"
-
-# Generate HMAC-SHA256 signature
-SIG=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET_KEY" | cut -d' ' -f2)
-
-# Make request
-curl -X POST "${BASE_URL}/${METHOD}" \
-  -H "Content-Type: application/json" \
-  -H "User-Agent: crypto-com-exchange/1.0.1 (Skill)" \
-  -d "{
-    \"id\": ${ID},
-    \"method\": \"${METHOD}\",
-    \"api_key\": \"${API_KEY}\",
-    \"params\": {
-      \"instrument_name\": \"BTC_USDT\",
-      \"side\": \"BUY\",
-      \"type\": \"LIMIT\",
-      \"price\": \"50000.00\",
-      \"quantity\": \"0.001\"
-    },
-    \"sig\": \"${SIG}\",
-    \"nonce\": ${NONCE}
-  }"
+cdcx account summary -o json
 ```
 
-### Python
+If this returns "No credentials found" or HTTP 401, re-run `cdcx auth login --oauth`.
 
-```python
-import hmac
-import hashlib
-import time
-import json
-import requests
+## Environments
 
-API_KEY = "your_api_key"
-SECRET_KEY = "your_secret_key"
-BASE_URL = "https://api.crypto.com/exchange/v1"
+```bash
+cdcx --env production account summary    # Production (default)
+cdcx --env uat account summary           # UAT sandbox
+```
 
-MAX_LEVEL = 3
+| Environment | Base URL |
+|-------------|----------|
+| Production | `https://api.crypto.com/exchange/v1/` |
+| UAT Sandbox | `https://uat-api.3ona.co/exchange/v1/` |
 
+## Multiple Profiles
 
-def params_to_str(obj, level):
-    """
-    Recursively convert params to signing string.
-    Based on official Crypto.com reference implementation.
-    - Dict keys are sorted alphabetically
-    - Arrays: elements are concatenated directly (no indices)
-    - None values become 'null'
-    - Recursion limited to MAX_LEVEL depth
-    """
-    if level >= MAX_LEVEL:
-        return str(obj)
+```bash
+cdcx --profile uat account summary
+```
 
-    if not isinstance(obj, dict):
-        return str(obj)
+## MCP Server
 
-    return_str = ""
-    for key in sorted(obj):
-        return_str += key
-        if obj[key] is None:
-            return_str += "null"
-        elif isinstance(obj[key], list):
-            for sub_obj in obj[key]:
-                return_str += params_to_str(sub_obj, level + 1)
-        else:
-            return_str += str(obj[key])
-    return return_str
+When running as an MCP server, credentials from `cdcx auth login --oauth` are used automatically:
 
-
-def sign_request(req: dict) -> None:
-    """Sign a request dict in-place by adding the 'sig' field."""
-    param_str = ""
-    if "params" in req:
-        param_str = params_to_str(req["params"], 0)
-
-    payload = req["method"] + str(req["id"]) + req["api_key"] + param_str + str(req["nonce"])
-    req["sig"] = hmac.new(
-        bytes(SECRET_KEY, "utf-8"),
-        msg=bytes(payload, "utf-8"),
-        digestmod=hashlib.sha256
-    ).hexdigest()
-
-
-def send_request(method: str, params: dict) -> dict:
-    """Send a signed request to the Crypto.com Exchange API."""
-    req = {
-        "id": 1,
-        "method": method,
-        "api_key": API_KEY,
-        "params": params,
-        "nonce": int(time.time() * 1000)
+```json
+{
+  "mcpServers": {
+    "cdcx": {
+      "command": "npx",
+      "args": ["-y", "@cryptocom/cdcx-cli@latest", "mcp"]
     }
-    sign_request(req)
-
-    response = requests.post(
-        f"{BASE_URL}/{method}",
-        json=req,
-        headers={
-            "Content-Type": "application/json",
-            "User-Agent": "crypto-com-exchange/1.0.1 (Skill)"
-        }
-    )
-    return response.json()
-
-
-# Example: Place a limit buy order
-result = send_request("private/create-order", {
-    "instrument_name": "BTC_USDT",
-    "side": "BUY",
-    "type": "LIMIT",
-    "price": "50000.00",
-    "quantity": "0.001"
-})
-print(json.dumps(result, indent=2))
+  }
+}
 ```
-
-### JavaScript / Node.js
-
-```javascript
-const crypto = require("crypto");
-
-const API_KEY = "your_api_key";
-const SECRET_KEY = "your_secret_key";
-const BASE_URL = "https://api.crypto.com/exchange/v1";
-
-/**
- * Convert params to signing string.
- * Based on official Crypto.com reference implementation.
- * - Object keys sorted alphabetically
- * - Arrays: elements concatenated directly (NO indices)
- * - null/undefined → ""
- */
-function isObject(obj) {
-  return obj !== undefined && obj !== null && obj.constructor === Object;
-}
-
-function isArray(obj) {
-  return obj !== undefined && obj !== null && obj.constructor === Array;
-}
-
-function arrayToString(arr) {
-  return arr.reduce((a, b) => {
-    return a + (isObject(b) ? objectToString(b) : isArray(b) ? arrayToString(b) : b);
-  }, "");
-}
-
-function objectToString(obj) {
-  if (obj == null) return "";
-  return Object.keys(obj)
-    .sort()
-    .reduce((a, b) => {
-      return (
-        a +
-        b +
-        (isArray(obj[b])
-          ? arrayToString(obj[b])
-          : isObject(obj[b])
-            ? objectToString(obj[b])
-            : obj[b])
-      );
-    }, "");
-}
-
-function signRequest(requestBody) {
-  const { id, method, params, nonce } = requestBody;
-  const paramsString = objectToString(params);
-  const sigPayload = method + id + API_KEY + paramsString + nonce;
-  requestBody.sig = crypto
-    .createHmac("sha256", SECRET_KEY)
-    .update(sigPayload)
-    .digest("hex");
-}
-
-async function sendRequest(method, params = {}) {
-  const body = {
-    id: 1,
-    method,
-    api_key: API_KEY,
-    params,
-    nonce: Date.now(),
-  };
-  signRequest(body);
-
-  const response = await fetch(`${BASE_URL}/${method}`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "User-Agent": "crypto-com-exchange/1.0.1 (Skill)",
-    },
-    body: JSON.stringify(body),
-  });
-  return response.json();
-}
-
-// Example: Place a limit buy order
-sendRequest("private/create-order", {
-  instrument_name: "BTC_USDT",
-  side: "BUY",
-  type: "LIMIT",
-  price: "50000.00",
-  quantity: "0.001",
-}).then((res) => console.log(JSON.stringify(res, null, 2)));
-```
-
-## Public Endpoint Example (No Auth)
-
-Public endpoints don't require `api_key` or `sig`:
-
-```bash
-curl -X GET "https://api.crypto.com/exchange/v1/public/get-tickers?instrument_name=BTC_USDT" \
-  -H "Content-Type: application/json" \
-  -H "User-Agent: crypto-com-exchange/1.0.1 (Skill)"
-```
-
-## Troubleshooting
-
-### Common Error Codes
-
-| Code | HTTP | Message Code | Description |
-|------|------|--------------|-------------|
-| 0 | 200 | -- | Success |
-| 40001 | 400 | BAD_REQUEST | Bad request |
-| 40002 | 400 | METHOD_NOT_FOUND | Method not found |
-| 40003 | 400 | INVALID_REQUEST | Invalid request |
-| 40004 | 400 | MISSING_OR_INVALID_ARGUMENT | Required argument is blank or missing |
-| 40101 | 401 | UNAUTHORIZED | Not authenticated, or key/signature incorrect |
-| 40102 | 400 | INVALID_NONCE | Nonce value differs by more than 60 seconds |
-| 40103 | 401 | IP_ILLEGAL | IP address not whitelisted |
-| 42901 | 429 | TOO_MANY_REQUESTS | Requests have exceeded rate limits |
-
-### Trading Error Codes
-
-| Code | HTTP | Message Code | Description |
-|------|------|--------------|-------------|
-| 204 | 400 | DUPLICATE_CLORDID | Duplicate client order id |
-| 208 | 400 | INSTRUMENT_NOT_TRADABLE | Instrument is not tradable |
-| 209 | 400 | INVALID_INSTRUMENT | Instrument is invalid |
-| 213 | 400 | INVALID_ORDERQTY | Invalid order quantity |
-| 218 | 400 | INVALID_ORDTYPE | Invalid order type |
-| 220 | 400 | INVALID_SIDE | Invalid side |
-| 221 | 400 | INVALID_TIF | Invalid time_in_force |
-| 224 | 400 | REJ_BY_MATCHING_ENGINE | Rejected by matching engine |
-| 229 | 400 | INVALID_REF_PRICE | Invalid ref price |
-| 306 | 500 | INSUFFICIENT_AVAILABLE_BALANCE | Insufficient available balance |
-| 308 | 400 | INVALID_PRICE | Invalid price |
-| 314 | 400 | EXCEEDS_MAX_ORDER_SIZE | Exceeds max order size |
-| 318 | 400 | EXCEEDS_MAX_ALLOWED_ORDERS | Exceeds max allowed orders |
-| 315 | 400 | FAR_AWAY_LIMIT_PRICE | Limit price too far from current market price |
-| 415 | 500 | BELOW_MIN_ORDER_SIZE | Below min order size |
-| 416 | 400 | USER_NO_MARGIN_ACCESS | Account does not have margin access |
-| 5000811 | 400 | WITHDRAW_ADDRESS_NOT_IN_WHITE_LIST | Withdrawal address not whitelisted in account settings |
-| 40401 | 404 | NOT_FOUND | Order/resource not found |
-| 43003 | 400 | FILL_OR_KILL | FOK order could not be fully filled (rejected) |
-| 43004 | 400 | IMMEDIATE_OR_CANCEL | IOC order could not be filled (rejected) |
-| 43005 | 400 | POST_ONLY_REJ | POST_ONLY order would have matched (rejected). Also returned for POST_ONLY on MARKET orders |
-| 140001 | 400 | API_DISABLED | Feature disabled for this endpoint (e.g., OCO on `create-order-list` instead of `advanced/create-oco`) |
-
-### Advanced Order Error Codes
-
-| Code | Message Code | Description |
-|------|--------------|-------------|
-| 50002 | INVALID_PRICE | Price too far from market or invalid for order type |
-| 50007 | INVALID_TRIGGER_PRICE | Trigger/ref_price direction is wrong relative to market price |
-| 50010 | INVALID_ORDER_PARAMETERS | Invalid order configuration (e.g., OTO/OTOCO with same-side orders) |
-
-### Tips
-
-* **Must be strings**: `price`, `quantity`, `notional`, `ref_price`, `amount`, `new_price`, `new_quantity` (e.g., `"0.001"` not `0.001`)
-* **Must be numbers**: `limit`, `end_time` on `user-balance-history` (e.g., `100` not `"100"`). Sending `limit` as string returns error 40003
-* **Accept both**: `page`, `page_size`, `count`, `depth`, `start_time`, `end_time` (trading history), `start_ts`, `end_ts`
-* Use UAT Sandbox for development: `https://uat-api.3ona.co/exchange/v1/`
-* UAT Sandbox credentials are separate from production
-* Add a 1-second delay after WebSocket connection before sending requests
-* Verify server time if nonce errors occur
-* Enable only required API permissions (no withdrawal access for trading-only keys)
-* Use IP whitelist in Crypto.com Exchange API settings
-
-## Security Notes
-
-* Never share your secret key
-* Use IP whitelist in API settings
-* Enable only required permissions (spot trading, no withdrawals)
-* Use UAT Sandbox for development and testing
-* Sandbox credentials are separate from production

--- a/crypto-com-exchange/references/install.md
+++ b/crypto-com-exchange/references/install.md
@@ -1,0 +1,89 @@
+# Installing cdcx CLI
+
+The `cdcx` CLI is the Crypto.com Exchange command-line tool that handles API calls, authentication, safety enforcement, and output formatting.
+
+## Quick Install (recommended)
+
+```bash
+npx @cryptocom/cdcx-cli@latest --version
+```
+
+This downloads and runs the latest version via npm. No global install needed — `npx` caches the binary automatically.
+
+## Global Install via npm
+
+```bash
+npm install -g @cryptocom/cdcx-cli
+cdcx --version
+```
+
+## Install via curl (direct binary)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/crypto-com/cdcx-cli/main/install.sh | sh
+```
+
+Downloads the pre-built Rust binary for your platform (macOS arm64/x64, Linux x64).
+
+## Install from Source (Rust)
+
+```bash
+cargo install cdcx-cli
+```
+
+Requires Rust toolchain (stable).
+
+## Verify Installation
+
+```bash
+cdcx --version
+# cdcx 1.2.4
+
+# Public endpoint (no auth needed)
+cdcx market ticker BTC_USDT -o json
+```
+
+## Update
+
+```bash
+# npm
+npm update -g @cryptocom/cdcx-cli
+
+# Or just use npx (always gets latest)
+npx @cryptocom/cdcx-cli@latest market ticker BTC_USDT
+```
+
+## Platform Support
+
+| Platform | Architecture | Method |
+|----------|-------------|--------|
+| macOS | arm64 (Apple Silicon) | npm, curl, cargo |
+| macOS | x64 (Intel) | npm, curl, cargo |
+| Linux | x64 | npm, curl, cargo |
+| Windows | x64 | npm, cargo |
+
+## AI Agent Plugin Install
+
+For AI coding tools (Claude Code, Cursor, Codex), the CLI is available as a plugin:
+
+```bash
+# Claude Code
+claude plugin add @cryptocom/cdcx-cli
+
+# Or configure manually in .claude/settings.json:
+# "mcpServers": {
+#   "cdcx": {
+#     "command": "npx",
+#     "args": ["-y", "@cryptocom/cdcx-cli@latest", "mcp"]
+#   }
+# }
+```
+
+## Troubleshooting
+
+| Issue | Fix |
+|-------|-----|
+| `command not found: cdcx` | Use `npx @cryptocom/cdcx-cli@latest` or add npm global bin to PATH |
+| Permission denied | `chmod +x $(which cdcx)` or reinstall with `sudo npm i -g` |
+| Old version | `npm update -g @cryptocom/cdcx-cli` or `cdcx update` |
+| Network error on install | Check proxy settings; try `curl` method instead |


### PR DESCRIPTION
## Summary

- **Replace raw API skill with `cdcx` CLI** — the exchange skill no longer maintains its own API endpoint definitions, authentication logic, or request signing. All execution is delegated to the [`cdcx` CLI](https://github.com/crypto-com/cdcx-cli), which is OpenAPI-driven and always current.
- **Simplify authentication** — removed 400+ lines of manual key setup. Auth is now a single `cdcx auth login --oauth` command that opens a browser, with auto-execution by the agent (no user intervention needed).
- **Add install reference** — new `references/install.md` covering npm, curl, cargo, and plugin install methods with troubleshooting.
- **Streamline SKILL.md** — reduced from ~550 lines of raw endpoint specs to ~230 lines of CLI usage patterns, recipes, and agent behavior rules.

## What Changed

| File | Change |
|------|--------|
| `SKILL.md` | Rewritten around `cdcx` CLI commands (market, trade, advanced, account, wallet, margin, paper, stream) |
| `references/authentication.md` | Replaced manual API key flow with OAuth CLI login |
| `references/install.md` | New — installation methods and troubleshooting |
| `README.md` | Updated to reflect CLI-based architecture |
| `.claude-plugin/plugin.json` | Simplified MCP server config |

## Motivation

Maintaining API endpoint definitions in the skill was error-prone — endpoints change, new ones get added, and the skill drifts from reality. The `cdcx` CLI is generated from the OpenAPI spec and handles auth/signing/safety automatically, so the skill just needs to know the command patterns.
